### PR TITLE
feat: players with admin flag are not shown in the list of names or c…

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -41,6 +41,12 @@ public class BaseConfigs : BasePluginConfig
     [JsonPropertyName("CommandCooldownSeconds")]
     public int CommandCooldownSeconds { get; set; } = 120;
 
+    [JsonPropertyName("DontCountAdmins")]
+    public bool DontCountAdmins { get; set; } = false;
+
+    [JsonPropertyName("AdminBypassFlag")]
+    public string AdminBypassFlag { get; set; } = "@css/generic";
+
     [JsonPropertyName("Command")]
     public List<string> Command { get; set; } = new List<string> { "css_need", ".need" };
 


### PR DESCRIPTION
…ounted in case they are in the spectator team or none (to be compatible with /hide command of simpleadmin); you can enable or disable this logic by setting `DontCountAdmins` to false